### PR TITLE
Use higher rate limit Jupiter URL

### DIFF
--- a/src/configs/mainnet.ts
+++ b/src/configs/mainnet.ts
@@ -4,7 +4,7 @@ export const mainnet: AllbridgeCoreSdkOptions = {
   coreApiUrl: "https://core.api.allbridgecoreapi.net",
   coreApiQueryParams: {},
   coreApiHeaders: {},
-  jupiterUrl: "https://quote-api.jup.ag/v6",
+  jupiterUrl: "https://public.jupiterapi.com",
   wormholeMessengerProgramId: "worm2ZoG2kUd4vFXhvjh93UUH596ayRfgQ2MgjNMTth",
   solanaLookUpTable: "2JcBAEVnAwVo4u8d61iqgHPrzZuugur7cVTjWubsVLHj",
   sorobanNetworkPassphrase: "Public Global Stellar Network ; September 2015",


### PR DESCRIPTION
This PR adjusts the API provided for the jupiter package. The default API was updated for swap/quote to leverage [jupiterapi.com](https://www.jupiterapi.com/). The API offers higher rate limits (up to 10 rps) along with a faster updated market cache. The [jupiterapi.com](https://www.jupiterapi.com/) market cache surfaces newly launched tokens faster since it doesn't require a certain volume/liquidity threshold to be met, along with an improved cadence of it being updated. _With that said, the API does take a small platform fee (0.2%) on swaps given the stability/rate limits/new markets it provides.

More details can be found on the site.